### PR TITLE
Add infrastructure template and operational documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# aws-saa-labs
+# AWS SAA Labs – Resume Site
+
+A compact bilingual resume site that serves static HTML from Amazon S3 behind CloudFront. A lightweight AWS serverless backend captures contact form submissions via API Gateway, stores them in DynamoDB, and relays notifications through Amazon SES.
+
+## Project Structure
+
+| Path | Description |
+| --- | --- |
+| `site/` | Static assets for the Chinese (`cn/`) and English (`index.html`) resume pages plus the shared profile image. |
+| `cloudformation/s3-cf-api-ddb-ses.yml` | Infrastructure-as-code template provisioning S3, CloudFront, API Gateway, Lambda, DynamoDB, and SES resources required for the site and contact form. |
+| `runbook.md` | Operational procedures for deploying and maintaining the stack. |
+
+## Prerequisites
+
+* AWS CLI v2 configured with credentials that can create IAM, S3, CloudFront, API Gateway, Lambda, DynamoDB, and SES resources.
+* An AWS Region where Amazon SES is available and sandbox restrictions have been lifted (or the notification email is verified).
+* Node.js or Python is **not** required locally—the static site can be edited directly and uploaded.
+
+## Deployment Overview
+
+1. Review and customize the parameters in `cloudformation/s3-cf-api-ddb-ses.yml` (bucket name, notification email, optional tags).
+2. Deploy the stack:
+   ```bash
+   aws cloudformation deploy \
+     --template-file cloudformation/s3-cf-api-ddb-ses.yml \
+     --stack-name cv-resume \
+     --capabilities CAPABILITY_NAMED_IAM \
+     --parameter-overrides \
+       SiteBucketName=my-unique-bucket \
+       NotificationEmail=you@example.com
+   ```
+3. Upload the contents of the `site/` folder to the provisioned bucket:
+   ```bash
+   aws s3 sync site/ s3://my-unique-bucket/
+   ```
+4. Wait for the CloudFront distribution to deploy and test the resume via the distribution domain name output by the stack.
+
+Additional operational details—such as handling content updates, invalidations, and troubleshooting—are documented in `runbook.md`.
+
+## Local Preview
+
+Open `site/index.html` or `site/cn/index.html` directly in a browser to preview the static content. Because the contact form relies on the deployed API Gateway endpoint, form submissions are only fully functional in the deployed environment.
+
+## License
+
+This repository is maintained as a personal lab project and does not currently define a formal license. Reach out before reusing code or assets.

--- a/cloudformation/s3-cf-api-ddb-ses.yml
+++ b/cloudformation/s3-cf-api-ddb-ses.yml
@@ -1,1 +1,301 @@
-111
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Resume site infrastructure with S3, CloudFront, API Gateway, Lambda, DynamoDB, and SES notification pipeline.
+
+Parameters:
+  SiteBucketName:
+    Type: String
+    Description: Globally unique bucket name that will host the static resume site.
+  NotificationEmail:
+    Type: String
+    Description: Verified email address used as both sender and recipient for contact notifications.
+  ProjectTag:
+    Type: String
+    Default: resume
+    Description: Value applied to the Project tag for all taggable resources.
+
+Resources:
+  ResumeBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref SiteBucketName
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectTag
+
+  ResumeBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ResumeBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowCloudFrontAccess
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: 's3:GetObject'
+            Resource: !Join
+              - ''
+              - - !GetAtt ResumeBucket.Arn
+                - '/*'
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/${ResumeDistribution}'
+
+  ResumeOAC:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub '${AWS::StackName}-oac'
+        OriginAccessControlOriginType: s3
+        SigningProtocol: sigv4
+        SigningBehavior: always
+
+  ResumeDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        DefaultRootObject: index.html
+        HttpVersion: http2
+        PriceClass: PriceClass_100
+        Origins:
+          - Id: resume-s3-origin
+            DomainName: !GetAtt ResumeBucket.RegionalDomainName
+            S3OriginConfig: {}
+            OriginAccessControlId: !Ref ResumeOAC
+        DefaultCacheBehavior:
+          TargetOriginId: resume-s3-origin
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods: [GET, HEAD, OPTIONS]
+          CachedMethods: [GET, HEAD]
+          Compress: true
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # CachingOptimized managed policy
+          ResponseHeadersPolicyId: 67f7725c-6f97-4210-82d7-5512b31e9d03 # CORS-With-Preflight managed policy
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectTag
+
+  ContactTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub '${AWS::StackName}-contact'
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: SubmissionId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: SubmissionId
+          KeyType: HASH
+      SSESpecification:
+        SSEEnabled: true
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectTag
+
+  ContactFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: contact-handler
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                Resource: !GetAtt ContactTable.Arn
+              - Effect: Allow
+                Action:
+                  - ses:SendEmail
+                  - ses:SendRawEmail
+                Resource: '*'
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectTag
+
+  ContactFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.11
+      Handler: index.handler
+      Role: !GetAtt ContactFunctionRole.Arn
+      Timeout: 10
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref ContactTable
+          NOTIFICATION_EMAIL: !Ref NotificationEmail
+      Code:
+        ZipFile: |-
+          import json
+          import os
+          from datetime import datetime
+          from uuid import uuid4
+
+          import boto3
+
+          dynamodb = boto3.resource('dynamodb')
+          ses = boto3.client('ses')
+
+          TABLE_NAME = os.environ['TABLE_NAME']
+          NOTIFICATION_EMAIL = os.environ['NOTIFICATION_EMAIL']
+
+          def handler(event, context):
+              try:
+                  body = json.loads(event.get('body') or '{}')
+              except json.JSONDecodeError:
+                  return _response(400, {'message': 'Invalid JSON body.'})
+
+              name = (body.get('name') or '').strip()
+              email = (body.get('email') or '').strip()
+              message = (body.get('message') or '').strip()
+
+              if not name or not email or not message:
+                  return _response(400, {'message': 'name, email, and message are required.'})
+
+              submission_id = str(uuid4())
+              timestamp = datetime.utcnow().isoformat() + 'Z'
+
+              table = dynamodb.Table(TABLE_NAME)
+              table.put_item(
+                  Item={
+                      'SubmissionId': submission_id,
+                      'CreatedAt': timestamp,
+                      'Name': name,
+                      'Email': email,
+                      'Message': message,
+                  }
+              )
+
+              subject = f'New resume contact from {name}'
+              body_text = (
+                  f'Name: {name}\n'
+                  f'Email: {email}\n'
+                  f'Message:\n{message}\n\n'
+                  f'Submitted at {timestamp}'
+              )
+
+              ses.send_email(
+                  Source=NOTIFICATION_EMAIL,
+                  Destination={'ToAddresses': [NOTIFICATION_EMAIL]},
+                  Message={
+                      'Subject': {'Data': subject, 'Charset': 'UTF-8'},
+                      'Body': {'Text': {'Data': body_text, 'Charset': 'UTF-8'}},
+                  },
+              )
+
+              return _response(200, {'message': 'Submission received.'})
+
+          def _response(status, body):
+              return {
+                  'statusCode': status,
+                  'headers': {
+                      'Access-Control-Allow-Origin': '*',
+                      'Access-Control-Allow-Headers': '*',
+                  },
+                  'body': json.dumps(body),
+              }
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectTag
+
+  ContactApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: !Sub '${AWS::StackName}-contact'
+      ProtocolType: HTTP
+      CorsConfiguration:
+        AllowOrigins:
+          - '*'
+        AllowHeaders:
+          - '*'
+        AllowMethods:
+          - POST
+      Tags:
+        Project: !Ref ProjectTag
+
+  ContactIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref ContactApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt ContactFunction.Arn
+      PayloadFormatVersion: '2.0'
+
+  ContactRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref ContactApi
+      RouteKey: 'POST /contact'
+      Target: !Sub 'integrations/${ContactIntegration}'
+
+  ContactStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref ContactApi
+      StageName: '$default'
+      AutoDeploy: true
+      Tags:
+        Project: !Ref ProjectTag
+
+  ContactPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref ContactFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ContactApi}/*/POST/contact'
+
+  ContactTableNameMapping:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/contact-table'
+      Type: String
+      Value: !Ref ContactTable
+      Tags:
+        Project: !Ref ProjectTag
+
+  ContactApiEndpointParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/contact-endpoint'
+      Type: String
+      Value: !Sub 'https://${ContactApi}.execute-api.${AWS::Region}.amazonaws.com/contact'
+      Tags:
+        Project: !Ref ProjectTag
+
+  NotificationIdentity:
+    Type: AWS::SES::EmailIdentity
+    Properties:
+      EmailIdentity: !Ref NotificationEmail
+
+Outputs:
+  ResumeBucket:
+    Description: S3 bucket name hosting the resume.
+    Value: !Ref ResumeBucket
+  CloudFrontDomain:
+    Description: CloudFront distribution domain for the resume.
+    Value: !GetAtt ResumeDistribution.DomainName
+  ContactApiEndpoint:
+    Description: HTTPS endpoint for the contact form submissions.
+    Value: !Sub 'https://${ContactApi}.execute-api.${AWS::Region}.amazonaws.com/contact'
+  ContactTableName:
+    Description: DynamoDB table storing contact submissions.
+    Value: !Ref ContactTable

--- a/runbook.md
+++ b/runbook.md
@@ -1,0 +1,91 @@
+# Resume Platform Runbook
+
+This runbook documents the operational steps required to deploy, operate, and troubleshoot the resume site and contact form stack defined in `cloudformation/s3-cf-api-ddb-ses.yml`.
+
+## 1. Stack Deployment / Update
+
+1. **Prepare parameters**
+   * `SiteBucketName` must be globally unique (e.g., `cv-yourname-prod`).
+   * `NotificationEmail` must be verified in Amazon SES (the template creates the identity, but you must confirm the verification email).
+   * Optionally adjust the `ProjectTag` parameter to match your tagging standard.
+2. **Deploy or update**
+   ```bash
+   aws cloudformation deploy \
+     --template-file cloudformation/s3-cf-api-ddb-ses.yml \
+     --stack-name cv-resume \
+     --capabilities CAPABILITY_NAMED_IAM \
+     --parameter-overrides \
+       SiteBucketName=cv-yourname-prod \
+       NotificationEmail=you@example.com \
+       ProjectTag=resume
+   ```
+3. Wait for the stack to finish. Confirm outputs:
+   * `CloudFrontDomain` – public URL to the resume.
+   * `ContactApiEndpoint` – HTTPS endpoint for the contact form.
+   * `ResumeBucket` – name of the S3 bucket hosting the static assets.
+
+## 2. Verifying Amazon SES Identity
+
+1. After the first deployment you will receive a verification email at `NotificationEmail`.
+2. Click the verification link to activate the SES identity.
+3. Once verified, move the SES configuration set from sandbox (if necessary) and request production access if you need to email unverified recipients.
+
+## 3. Publishing Site Content
+
+1. Build or edit HTML in the `site/` directory.
+2. Sync the files to S3 (this preserves existing objects and uploads changes):
+   ```bash
+   aws s3 sync site/ s3://cv-yourname-prod/ --delete
+   ```
+3. Invalidate the CloudFront cache to propagate changes quickly:
+   ```bash
+   aws cloudfront create-invalidation \
+     --distribution-id <DistributionId> \
+     --paths '/*'
+   ```
+   The distribution ID is available in the CloudFormation console under the distribution resource.
+
+## 4. Monitoring & Logs
+
+* **CloudFront** – Check the CloudFront console for error rates and request metrics.
+* **Lambda & API Gateway** – Use CloudWatch Logs (`/aws/lambda/<function-name>`) for request/response details. CloudWatch metrics can alert on high 5XX error counts.
+* **DynamoDB** – Monitor consumed capacity if the contact form begins receiving significant traffic.
+* **SES** – Review delivery reports and bounces to ensure the notification email remains healthy.
+
+## 5. Backup & Data Export
+
+* Enable DynamoDB point-in-time recovery if long-term retention is required (not enabled by default in the template).
+* To export submissions, run:
+  ```bash
+  TABLE_NAME=$(aws cloudformation describe-stacks \
+    --stack-name cv-resume \
+    --query 'Stacks[0].Outputs[?OutputKey==`ContactTableName`].OutputValue' \
+    --output text)
+  aws dynamodb scan \
+    --table-name "$TABLE_NAME" \
+    --region <region> \
+    --output json > submissions.json
+  ```
+
+## 6. Troubleshooting
+
+| Symptom | Checks |
+| --- | --- |
+| Static site returns 403 | Ensure files are uploaded to the correct bucket prefix and the CloudFront invalidation has completed. |
+| Contact form fails with 500 | Inspect the Lambda logs for stack traces; verify DynamoDB and SES IAM permissions are intact. |
+| SES email not delivered | Confirm the identity is verified and the region has exited sandbox mode; review suppression list. |
+| CloudFormation rollback | Review the Events tab for the failing resource. Common issues include bucket name collisions or SES verification pending. |
+
+## 7. Teardown
+
+1. Empty the S3 bucket:
+   ```bash
+   aws s3 rm s3://cv-yourname-prod --recursive
+   ```
+2. Delete the CloudFormation stack:
+   ```bash
+   aws cloudformation delete-stack --stack-name cv-resume
+   ```
+3. Optionally remove the SES identity manually if you no longer need to send emails from it.
+
+Keep this document updated whenever operational procedures change.


### PR DESCRIPTION
## Summary
- replace the placeholder README with deployment-focused project documentation
- add a comprehensive runbook covering deployment, updates, monitoring, and teardown
- introduce a full CloudFormation template for the S3 + CloudFront resume site with contact pipeline services

## Testing
- not run (documentation and infrastructure template only)


------
https://chatgpt.com/codex/tasks/task_b_68e4f0ae97a88320ab5926ec00e129ef