### PR TITLE
Restyle Chinese resume page to match main layout

### DIFF
--- a/site/cn/index.html
+++ b/site/cn/index.html
@@ -2,152 +2,136 @@
 <html lang="zh-CN">
 <head>
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>高传晔｜云架构师</title>
   <meta name="description" content="高传晔 - 云架构师 求职简历（Golang/Java/Python、网络与安全、AWS、分布式与数据库调优）"/>
   <link rel="preload" href="/assets/profile.jpg" as="image">
-  <link rel="stylesheet" href="./style.css">
+  <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
-  <!-- 右侧英文切换按钮 -->
-  <a class="lang-switch" href="https://cv.whynotcloud.ltd/" target="_blank" rel="noopener">English</a>
-
   <div class="wrap">
-    <header class="header">
-      <img class="avatar" src="/assets/profile.jpg" alt="个人头像">
-      <div class="intro">
-        <h1>高传晔</h1>
-        <div class="chips">
-          <span>AWS 认证云从业者</span>
-          <span>云架构师（求职）</span>
-          <span>安全/后端/DevOps</span>
+    <header class="site-header">
+      <div class="header-left">
+        <img src="/assets/profile.jpg" alt="个人头像" class="avatar">
+        <div>
+          <h1>高传晔</h1>
+          <div class="chips">
+            <span>AWS 认证云从业者</span>
+            <span>云架构师（求职）</span>
+            <span>安全 / 后端 / DevOps</span>
+          </div>
+          <div class="links">
+            <a href="tel:19838638832">198-3863-8832</a> ·
+            <a href="mailto:3109158767@qq.com">3109158767@qq.com</a> ·
+            <a href="https://github.com/Apolonia-Vitali-Corleone" rel="noopener" target="_blank">GitHub</a> ·
+            <a href="/resume.pdf" rel="noopener" target="_blank">PDF</a>
+          </div>
         </div>
-        <p class="links">
-          <a href="tel:19838638832">198-3863-8832</a> ·
-          <a href="mailto:3109158767@qq.com">3109158767@qq.com</a> ·
-          <a href="https://github.com/Apolonia-Vitali-Corleone" target="_blank" rel="noopener">GitHub</a> ·
-          <a href="/resume.pdf" target="_blank" rel="noopener">PDF</a>
-        </p>
+      </div>
+      <div class="header-right">
+        <a href="/" class="lang-btn" aria-label="Switch to English">English</a>
       </div>
     </header>
 
-    <section>
-      <h2>求职目标</h2>
-      <p>
-        面向云架构师岗位，聚焦 <b>AWS</b> 与开源生态，擅长基于 <b>Golang/Java/Python</b> 的后端与平台工程，
-        具备网络与安全实战经验（渗透测试、合规评测），熟悉 <b>TCP/IP、HTTP、Linux、Docker、MySQL/Redis</b> 与分布式架构。
-        希望在云上完成从需求评审、方案设计、成本与可靠性权衡到落地的端到端交付。
-      </p>
-    </section>
+    <main>
+      <section>
+        <h2>求职目标</h2>
+        <p>
+          面向云架构师岗位，聚焦 <b>AWS</b> 与开源生态，擅长基于 <b>Golang/Java/Python</b> 的后端与平台工程，
+          具备网络与安全实战经验（渗透测试、合规评测），熟悉 <b>TCP/IP、HTTP、Linux、Docker、MySQL/Redis</b> 与分布式架构。
+          希望在云上完成从需求评审、方案设计、成本与可靠性权衡到落地的端到端交付。
+        </p>
+      </section>
 
-    <section>
-      <h2>教育背景</h2>
-      <ul class="list">
-        <li>
-          <div class="row">
-            <b>河南科技大学 · 物联网工程（本科）</b>
-            <span>2020.09 — 2024.07</span>
-          </div>
-          <div class="subrow">
-            <span>GPA：3.82（前 20%）</span>
-          </div>
-        </li>
-      </ul>
-    </section>
+      <section>
+        <h2>教育背景</h2>
+        <ul>
+          <li>
+            <b>河南科技大学 · 物联网工程（本科）</b> — 2020.09 至 2024.07
+            <div>GPA：3.82（前 20%）</div>
+          </li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>工作 / 实习</h2>
-      <ul class="list">
-        <li>
-          <div class="row">
-            <b>中国电信 · 新疆</b><span>IT 技术支持</span>
-            <span>2025 — 至今</span>
-          </div>
-        </li>
-        <li>
-          <div class="row">
-            <b>绿盟科技集团股份有限公司（深圳分公司）</b><span>安全服务工程师（实习）</span>
-            <span>2023.10 — 2023.12</span>
-          </div>
-          <ul class="bullets">
-            <li>参与渗透测试，使用 <b>BurpSuite / SQLMap / Metasploit</b> 评估 Web 与内网安全。</li>
-            <li>参与车企业务，基于 <b>ZCANPRO</b>、BurpSuite 进行车辆性能与安全测试。</li>
-            <li>输出测试与合规报告，支撑车企产品通过合规性审查与整改闭环。</li>
-            <li>为医院、政府、金融等客户执行漏洞扫描与复测，响应诉求并获得客户好评。</li>
-          </ul>
-        </li>
-      </ul>
-    </section>
+      <section>
+        <h2>工作 / 实习</h2>
+        <ul>
+          <li><b>中国电信 · 新疆</b> — IT 技术支持（2025 至今）</li>
+          <li>
+            <b>绿盟科技集团股份有限公司（深圳）</b> — 安全服务工程师（实习，2023.10 至 2023.12）
+            <ul>
+              <li>参与渗透测试，使用 <b>BurpSuite / SQLMap / Metasploit</b> 评估 Web 与内网安全。</li>
+              <li>配合车企业务，基于 <b>ZCANPRO</b> 与 BurpSuite 进行车辆性能与安全测试。</li>
+              <li>输出测试与合规报告，支撑车企产品通过合规性审查与整改闭环。</li>
+              <li>为医院、政府、金融等客户执行漏洞扫描与复测，响应诉求并获得客户好评。</li>
+            </ul>
+          </li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>项目与研究</h2>
-      <ul class="list">
-        <li>
-          <div class="row">
-            <b>orderEZ</b><span>Golang · Gin · Redis · MySQL · RabbitMQ</span>
-          </div>
-          <ul class="bullets">
-            <li>实现 <b>幂等</b> 与库存扣减 Lua 脚本；引入 <b>DLQ</b> 保障消息可靠性。</li>
-            <li>分层架构（repo / service / handler），便于扩展与单元测试。</li>
-          </ul>
-        </li>
-        <li>
-          <div class="row">
-            <b>Event Marketing</b><span>Gin/GORM · Redis/MySQL</span>
-          </div>
-          <ul class="bullets">
-            <li>设计优惠券与折扣模型，支持并发校验与一致性约束。</li>
-            <li>抽象缓存层，降低数据库压力并提升热点请求命中率。</li>
-          </ul>
-        </li>
-        <li>
-          <div class="row">
-            <b>基于深度学习的金融时间序列预测</b><span>毕业论文 · PyTorch</span>
-            <span>2023.12 — 2024.05</span>
-          </div>
-          <ul class="bullets">
-            <li>对比 <b>RNN/LSTM/GRU</b> 在股票预测中的表现，构建可复现实验框架。</li>
-            <li>在硬件资源约束下设计参数搜索策略，提升训练效率与效果。</li>
-          </ul>
-        </li>
-      </ul>
-    </section>
+      <section>
+        <h2>项目与研究</h2>
+        <ul>
+          <li>
+            <b>orderEZ</b> — Golang · Gin · Redis · MySQL · RabbitMQ
+            <ul>
+              <li>实现 <b>幂等</b> 与库存扣减 Lua 脚本；引入 <b>DLQ</b> 保障消息可靠性。</li>
+              <li>分层架构（repo / service / handler），便于扩展与单元测试。</li>
+            </ul>
+          </li>
+          <li>
+            <b>Event Marketing</b> — Gin/GORM · Redis/MySQL
+            <ul>
+              <li>设计优惠券与折扣模型，支持并发校验与一致性约束。</li>
+              <li>抽象缓存层，降低数据库压力并提升热点请求命中率。</li>
+            </ul>
+          </li>
+          <li>
+            <b>基于深度学习的金融时间序列预测</b> — 毕业论文 · PyTorch（2023.12 至 2024.05）
+            <ul>
+              <li>对比 <b>RNN/LSTM/GRU</b> 在股票预测中的表现，构建可复现实验框架。</li>
+              <li>在硬件资源约束下设计参数搜索策略，提升训练效率与效果。</li>
+            </ul>
+          </li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>技能</h2>
-      <ul class="skill-grid">
-        <li><b>语言</b>：C/C++、Golang、Java、Python</li>
-        <li><b>算法与结构</b>：链表/栈/队列、排序/递归/动态规划（LeetCode 题解）</li>
-        <li><b>网络与安全</b>：TCP/IP、HTTP、Wireshark 抓包、渗透测试与漏洞扫描</li>
-        <li><b>数据库</b>：MySQL、Redis；索引与 SQL 调优、分库分表、分布式架构</li>
-        <li><b>后端框架</b>：Spring Boot、Flask、Gin；前端：Vue 3</li>
-        <li><b>云与平台</b>：AWS（S3、CloudFront、IAM、Lambda、API Gateway、RDS）、Docker、Linux、Shell</li>
-        <li><b>工程实践</b>：测试报告与合规文档、性能与可靠性权衡、问题定位与复盘</li>
-      </ul>
-    </section>
+      <section>
+        <h2>技能</h2>
+        <ul>
+          <li><b>语言：</b>C/C++、Golang、Java、Python</li>
+          <li><b>算法与结构：</b>链表/栈/队列、排序/递归/动态规划（LeetCode 题解）</li>
+          <li><b>网络与安全：</b>TCP/IP、HTTP、Wireshark 抓包、渗透测试与漏洞扫描</li>
+          <li><b>数据库：</b>MySQL、Redis；索引与 SQL 调优、分库分表、分布式架构</li>
+          <li><b>后端框架：</b>Spring Boot、Flask、Gin；前端：Vue 3</li>
+          <li><b>云与平台：</b>AWS（S3、CloudFront、IAM、Lambda、API Gateway、RDS）、Docker、Linux、Shell</li>
+          <li><b>工程实践：</b>测试报告与合规文档、性能与可靠性权衡、问题定位与复盘</li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>证书与竞赛</h2>
-      <ul class="list">
-        <li><b>英语四级 CET-4</b>（569 分）</li>
-        <li>第八届“东方财富杯”全国大学生金融挑战赛 <b>省赛三等奖</b></li>
-        <li>第五届“强网杯”全国网络安全挑战赛 <b>强网先锋奖</b>（前 15%）</li>
-      </ul>
-    </section>
+      <section>
+        <h2>证书与竞赛</h2>
+        <ul>
+          <li><b>英语四级 CET-4</b>（569 分）</li>
+          <li>第八届“东方财富杯”全国大学生金融挑战赛 <b>省赛三等奖</b></li>
+          <li>第五届“强网杯”全国网络安全挑战赛 <b>强网先锋奖</b>（前 15%）</li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>个人优势</h2>
-      <ul class="bullets">
-        <li>英语读写能力强，可作为日常工作语言。</li>
-        <li>抗压能力强，能适应频繁与长期出差。</li>
-      </ul>
-    </section>
+      <section>
+        <h2>个人优势</h2>
+        <ul>
+          <li>英语读写能力强，可作为日常工作语言。</li>
+          <li>抗压能力强，能适应频繁与长期出差。</li>
+        </ul>
+      </section>
+    </main>
 
-    <footer class="footer">
-      <span>最后更新：<span id="last-updated">—</span></span>
+    <footer>
+      最后更新：<span id="last-updated">—</span>
     </footer>
   </div>
 
-  <script src="./app.js"></script>
+  <script defer src="app.js"></script>
 </body>
 </html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,1 +1,117 @@
-/* ???? */:root {  --fg: #111;  --muted: #666;  --chip: #ddd;  --link: #0969da;  --border: #e5e7eb;}* { box-sizing: border-box; }html, body {  margin: 0;  color: var(--fg);  line-height: 1.6;  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;  background: #fff;}.wrap { max-width: 880px; margin: 40px auto; padding: 0 20px; }a { color: var(--link); text-decoration: none; }a:hover { text-decoration: underline; }h1 { margin: 0 0 6px; line-height: 1.25; }h2 { margin: 24px 0 8px; }/* ???? */.site-header {  display: flex;  align-items: center;  justify-content: space-between;  gap: 16px;}.header-left {  display: flex;  gap: 20px;  align-items: center;}.header-right {  display: flex;  align-items: center;}/* ????????:??96px,??12vw,??160px */.avatar {  width: clamp(96px, 12vw, 160px);  height: clamp(96px, 12vw, 160px);  border-radius: 50%;  object-fit: cover;  flex: 0 0 auto;}/* ??/???? */.chips span {  display: inline-block;  border: 1px solid var(--chip);  border-radius: 999px;  padding: 2px 10px;  margin-right: 6px;  font-size: 12px;  color: var(--muted);}section { margin-top: 28px; }.links { color: var(--muted); }/* ???? */.lang-btn {  border: 1px solid var(--border);  background: #fff;  border-radius: 999px;  padding: 8px 14px;  font-size: 14px;  cursor: pointer;  transition: box-shadow .15s ease, transform .05s ease;}.lang-btn:hover { box-shadow: 0 2px 10px rgba(0,0,0,.06); }.lang-btn:active { transform: translateY(1px); }/* ???? */@media (max-width: 520px) {  .wrap { margin: 24px auto; }  .header-left { align-items: flex-start; }  .chips span { margin-bottom: 6px; }}
+/* ???? */
+:root {
+  --fg: #111;
+  --muted: #666;
+  --chip: #ddd;
+  --link: #0969da;
+  --border: #e5e7eb;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  color: var(--fg);
+  line-height: 1.6;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  background: #fff;
+}
+
+.wrap { max-width: 880px; margin: 40px auto; padding: 0 20px; }
+
+a { color: var(--link); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1 { margin: 0 0 6px; line-height: 1.25; }
+h2 { margin: 24px 0 8px; }
+
+/* ???? */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.header-left {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+}
+
+/* ????????:??96px,??12vw,??160px */
+.avatar {
+  width: clamp(96px, 12vw, 160px);
+  height: clamp(96px, 12vw, 160px);
+  border-radius: 50%;
+  object-fit: cover;
+  flex: 0 0 auto;
+}
+
+/* ??/???? */
+.chips span {
+  display: inline-block;
+  border: 1px solid var(--chip);
+  border-radius: 999px;
+  padding: 2px 10px;
+  margin-right: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+section { margin-top: 28px; }
+
+.links { color: var(--muted); }
+
+/* ???? */
+.lang-btn {
+  border: 1px solid var(--border);
+  background: #fff;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: box-shadow .15s ease, transform .05s ease;
+}
+
+.lang-btn:hover { box-shadow: 0 2px 10px rgba(0,0,0,.06); }
+.lang-btn:active { transform: translateY(1px); }
+
+/* ???? */
+@media (max-width: 520px) {
+  .wrap { margin: 24px auto; }
+  .header-left { align-items: flex-start; }
+  .chips span { margin-bottom: 6px; }
+}
+
+.lang-btn {
+  color: var(--fg);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+
+.lang-btn:visited { color: var(--fg); }
+
+main ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+main li { margin-bottom: 6px; }
+
+main ul ul { margin-top: 6px; }
+
+footer {
+  margin: 32px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  text-align: right;
+}
+:root {  --fg: #111;  --muted: #666;  --chip: #ddd;  --link: #0969da;  --border: #e5e7eb;}* { box-sizing: border-box; }html, body {  margin: 0;  color: var(--fg);  line-height: 1.6;  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;  background: #fff;}.wrap { max-width: 880px; margin: 40px auto; padding: 0 20px; }a { color: var(--link); text-decoration: none; }a:hover { text-decoration: underline; }h1 { margin: 0 0 6px; line-height: 1.25; }h2 { margin: 24px 0 8px; }/* ???? */.site-header {  display: flex;  align-items: center;  justify-content: space-between;  gap: 16px;}.header-left {  display: flex;  gap: 20px;  align-items: center;}.header-right {  display: flex;  align-items: center;}/* ????????:??96px,??12vw,??160px */.avatar {  width: clamp(96px, 12vw, 160px);  height: clamp(96px, 12vw, 160px);  border-radius: 50%;  object-fit: cover;  flex: 0 0 auto;}/* ??/???? */.chips span {  display: inline-block;  border: 1px solid var(--chip);  border-radius: 999px;  padding: 2px 10px;  margin-right: 6px;  font-size: 12px;  color: var(--muted);}section { margin-top: 28px; }.links { color: var(--muted); }/* ???? */.lang-btn {  border: 1px solid var(--border);  background: #fff;  border-radius: 999px;  padding: 8px 14px;  font-size: 14px;  cursor: pointer;  transition: box-shadow .15s ease, transform .05s ease;}.lang-btn:hover { box-shadow: 0 2px 10px rgba(0,0,0,.06); }.lang-btn:active { transform: translateY(1px); }/* ???? */@media (max-width: 520px) {  .wrap { margin: 24px auto; }  .header-left { align-items: flex-start; }  .chips span { margin-bottom: 6px; }}


### PR DESCRIPTION
## Summary
- align the Chinese resume page markup with the main site's structure and navigation
- reuse the shared stylesheet and extend it with styles for nested lists and the footer

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e684b94e508320943f8c8099402f5b